### PR TITLE
Hide astroplan import until actually needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ dist/
 noarch/
 
 rascil.egg-info/
+
+examples/random/

--- a/rascil/__init__.py
+++ b/rascil/__init__.py
@@ -1,5 +1,4 @@
 
-import warnings
 from . import data_models
 from . import processing_components
 from . import workflows

--- a/rascil/__init__.py
+++ b/rascil/__init__.py
@@ -5,8 +5,5 @@ from . import workflows
 
 from .processing_components.util.installation_checks import check_data_directory
 
-from astroplan import get_IERS_A_or_workaround
-get_IERS_A_or_workaround()
-
 check_data_directory()
 

--- a/rascil/processing_components/calibration/operations.py
+++ b/rascil/processing_components/calibration/operations.py
@@ -12,7 +12,7 @@ import logging
 from typing import Union
 
 import numpy.linalg
-from astropy.visualization import time_support
+#from astropy.visualization import time_support
 from astropy.time import Time
 
 from rascil.data_models.memory_data_models import GainTable, BlockVisibility, QA, assert_vis_gt_compatible
@@ -293,9 +293,11 @@ def gaintable_plot(gt: GainTable, cc="T", title='', ants=None, channels=None, la
         labels = ['' for ant in ants]
         
 
-    with time_support(format = 'iso', scale = 'utc'):
+    # with time_support(format = 'iso', scale = 'utc'):
+    if True:
         
-        time_axis = Time(gt.time/86400.0, format='mjd', out_subfmt='str')
+        # time_axis = Time(gt.time/86400.0, format='mjd', out_subfmt='str')
+        time_axis = gt.time / 86400.0
    
         if cc == "B":
 

--- a/rascil/processing_components/visibility/base.py
+++ b/rascil/processing_components/visibility/base.py
@@ -16,7 +16,6 @@ import re
 from typing import Union
 
 import numpy
-from astroplan import Observer
 from astropy import units as u, constants as constants
 from astropy.coordinates import SkyCoord
 from astropy.io import fits

--- a/rascil/processing_components/visibility/operations.py
+++ b/rascil/processing_components/visibility/operations.py
@@ -23,7 +23,6 @@ import logging
 from typing import Union, List
 
 import numpy
-from astroplan import Observer
 from astropy.time import Time
 from astropy.coordinates import Angle, SkyCoord
 
@@ -510,6 +509,7 @@ def calculate_blockvisibility_hourangles(bvis, direction=None):
     if direction is None:
         direction = bvis.phasecentre
 
+    from astroplan import Observer
     site = Observer(location=bvis.configuration.location)
     utc = Time(bvis.time / 86400.0, format='mjd', scale='utc')
     return site.target_hour_angle(utc, direction).wrap_at('180d')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aotools
-astropy>=4.0
+astropy<4.0
 astroplan
 bokeh
 dask


### PR DESCRIPTION
The import of astroplan causes an update of the astropy IERS cache. This causes lock conflicts when using Dask so we don't want the import at the module level.